### PR TITLE
General changes to workflow and features

### DIFF
--- a/lpm.sh
+++ b/lpm.sh
@@ -119,13 +119,13 @@ if [[ ! -f lpm.lock ]]; then
 fi
 
 case $1 in
-"build_release" | "build") lpm_build_release ;;
-"build_debug") lpm_build_debug ;;
-"clean") lpm_clean ;;
-"clone") lpm_clone ;;
-"update") lpm_update ;;
-"lock") lpm_lock ;;
-*)
+    "build_release" | "build") lpm_build_release ;;
+    "build_debug") lpm_build_debug ;;
+    "clean") lpm_clean ;;
+    "clone") lpm_clone ;;
+    "update") lpm_update ;;
+    "lock") lpm_lock ;;
+    *)
     echo "Error: valid commands are: build_release build_debug build clean clone update lock"
     exit 2
     ;;

--- a/lpm.sh
+++ b/lpm.sh
@@ -137,7 +137,7 @@ case $1 in
     "update") lpm_update ;;
     "lock") lpm_lock ;;
     *)
-        echo "Error: valid commands are: build_release build_debug build clean clone update lock"
+        echo "Error: valid commands are: build_release build_debug clean clone update lock"
         exit 2
         ;;
 esac

--- a/lpm.sh
+++ b/lpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-export PREFIX=./install
+export PREFIX=${CONDA_PREFIX}
 export CMAKE_PREFIX_PATH=${PREFIX}:${CMAKE_PREFIX_PATH}
 
 # clone all projects
@@ -10,19 +10,24 @@ function lpm_clone {
         IFS='	' read -r -a split <<< "${source}"
         NAME="${split[0]}"
         URL="${split[1]}"
-        BRANCH="${split[2]}"
+        REVISION="${split[2]}"
         if [[ ! -d ${NAME} ]]
         then
             echo "[LPM] Clone ${NAME}"
-            git clone --recursive --branch "${BRANCH}" "${URL}" "${NAME}"
+            git clone --recursive "${URL}" "${NAME}"
             git -C "${NAME}" remote set-url lpm "${URL}"
         fi
         if [[ -f lpm.lock ]]
         then
-            COMMIT="$(grep "${NAME}" lpm.lock | cut -f1)"
-            git -C "${NAME}" checkout "${COMMIT}"
+	        URL_LOCK="$(grep "${NAME}" lpm.lock | cut -f2)"
+            COMMIT_LOCK="$(grep "${NAME}" lpm.lock | cut -f3)"
+            echo "[LPM] Read commit ${COMMIT_LOCK} for ${NAME}"
+	        git -C "${NAME}" remote set-url lpm "${URL_LOCK}"
+	        git -C "${NAME}" fetch lpm
+	        git -C "${NAME}" checkout "${COMMIT_LOCK}"
         else
-            git -C "${NAME}" checkout "${BRANCH}"
+            git -C "${NAME}" checkout "${REVISION}"
+	        git pull
         fi
     done < lpm.tsv
 }
@@ -34,11 +39,11 @@ function lpm_update {
         IFS='	' read -r -a split <<< "${source}"
         NAME="${split[0]}"
         URL="${split[1]}"
-        BRANCH="${split[2]}"
+        REVISION="${split[2]}"
         echo "[LPM] Update ${NAME}"
         git -C "${NAME}" remote set-url lpm "${URL}"
-        git -C "${NAME}" fetch lpm "${BRANCH}"
-        git -C "${NAME}" checkout "${BRANCH}"
+        git -C "${NAME}" fetch lpm
+        git -C "${NAME}" checkout "${REVISION}"
         git -C "${NAME}" reset --hard "lpm/${BRANCH}"
     done < lpm.tsv
     lpm_lock
@@ -51,11 +56,24 @@ function lpm_lock {
     do
         IFS='	' read -r -a split <<< "${source}"
         NAME="${split[0]}"
-        URL="${split[1]}"
-        BRANCH="${split[2]}"
+	    CMAKE_ARGS=""
+        if [[ "${#split[@]}" -eq 4 ]]
+        then
+            CMAKE_ARGS="${split[3]}"
+        fi
         echo "[LPM] Lock ${NAME}"
-        REV="$(git -C "${NAME}" rev-parse HEAD)"
-        echo "${NAME}	${REV}" >> lpm.tmp
+        set +e
+        {
+            URL_LOCK="$(git -C "${NAME}" remote get-url $(git -C "${NAME}" rev-parse --abbrev-ref --symbolic-full-name @{u} | cut -d'/' -f1))"
+        } || {
+            URL_LOCK="$(git -C "${NAME}" remote get-url lpm)"
+        } || {
+            URL_LOCK="$(git -C "${NAME}" remote get-url origin)"
+        }
+        set -e
+        echo "{LPM} locked ${URL_LOCK}"
+        REV_LOCK="$(git -C "${NAME}" rev-parse HEAD)"
+        echo "${NAME}	${URL_LOCK}	${REV_LOCK}	${CMAKE_ARGS}" >> lpm.tmp
     done < lpm.tsv
     mv lpm.tmp lpm.lock
 }
@@ -74,11 +92,19 @@ function lpm_build {
             CMAKE_ARGS="${split[3]}"
         fi
         echo "[LPM] Build ${NAME}"
-        cmake -S "${NAME}" -B "${NAME}/build" "-DCMAKE_INSTALL_PREFIX=${PREFIX}" ${CMAKE_ARGS}
-        cmake --build "${NAME}/build"
-        cmake --build "${NAME}/build" -t test
-        cmake --build "${NAME}/build" -t install
+        cmake -S "${NAME}" -B "${NAME}/build_${TYPE}" "-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=${TYPE} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=clang++" ${CMAKE_ARGS}
+        cmake --build "${NAME}/build_${TYPE}"
+        cmake --build "${NAME}/build_${TYPE}" -t test
+        cmake --build "${NAME}/build_${TYPE}" -t install
     done < lpm.tsv
+}
+function lpm_build_release {
+    TYPE="Release"
+    lpm_build
+}
+function lpm_build_debug {
+    TYPE="Debug"
+    lpm_build
 }
 
 # remove build caches
@@ -88,7 +114,7 @@ function lpm_clean {
         IFS='	' read -r -a split <<< "${source}"
         NAME="${split[0]}"
         echo "[LPM] Clean ${NAME}"
-        rm -rf "${NAME}/build"
+        rm -rf "${NAME}/build_*"
     done < lpm.tsv
 }
 
@@ -100,19 +126,18 @@ fi
 
 if [[ ! -f lpm.lock ]]
 then
-    echo "Warning: lpm.lock not found. Creating it..."
-    lpm_clone
-    lpm_lock
+    echo "Warning: lpm.lock not found. Using only lpm.tsv configuration file"
 fi
 
 case $1 in
-    ""|"build") lpm_build ;;
+    "build_release"|"build") lpm_build_release ;;
+    "build_debug") lpm_build_debug ;;
     "clean") lpm_clean ;;
     "clone") lpm_clone ;;
     "update") lpm_update ;;
     "lock") lpm_lock ;;
     *)
-        echo "Error: valid commands are: build clean clone update lock. build is the default"
+        echo "Error: valid commands are: build_release build_debug build clean clone update lock"
         exit 2
         ;;
 esac


### PR DESCRIPTION
I made some changes while adapting the framework to my install, here is a summary:
* Changed the install prefix (maybe we should read an env var instead?)
* Field BRANCH of the .tsv is now a revision instead of a branch, it changes the way repos are cloned (cannot only clone one branch I believe) 
* .lock file now also stores the cmake options from the .tsv
* Script can now be run without having a lock file in the current directory. In the older version this would trigger a pull according to the .tsv, eventually loosing the current state of the repos. (We should probably simply trigger the creation of a lock file ? Not that trivial)
* The stored URL in the lock file corresponds to the url associated with current HEAD of the repo instead of copying the .tsv URL
* Two build option, DEBUG and RELEASE, are now set by default by running commands `lpm build_release` and `lpm build_debug`

